### PR TITLE
Use `remq` instead of `delq` in `selectrum-prescient-create-and-bind-toggle-command`.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog].
 
+## Unreleased
+### Bugs fixed
+* Toggling off filter methods no longer accidentally changes the
+  global value of `prescient-filter-method`.  See [#123], [#124].
+
+[#123]: https://github.com/radian-software/prescient.el/issues/123
+[#124]: https://github.com/radian-software/prescient.el/pull/124
+
 ## 5.2.1 (released 2022-06-01)
 ### Bugs fixed
 * ivy doesn't convert all variables to string when sorting or calling

--- a/selectrum-prescient.el
+++ b/selectrum-prescient.el
@@ -195,7 +195,10 @@ buffer. It does not affect the default behavior (determined by
 
              (setq prescient-filter-method
                    (if (memq ',filter-type prescient-filter-method)
-                       (delq ',filter-type prescient-filter-method)
+                       ;; Even when running `make-local-variable',
+                       ;; it seems `delq' might still modify the
+                       ;; global value, so we use `remq' here.
+                       (remq ',filter-type prescient-filter-method)
                      (cons ',filter-type prescient-filter-method)))))
 
          ;; After changing `prescient-filter-method', tell the user


### PR DESCRIPTION
Even though we use `make-local-variable` to ensure that
`prescient-filter-method` is buffer-local in the minibuffer, it seems
that `delq` might still modify `prescient-filter-method` as a global
variable.  It was assumed that destructive functions would only modify
the buffer-local value, but that is apparently not the case.

See also issue #123.

<!--

To expedite the pull request process, please see the contributor guide
for my projects:

  <https://github.com/raxod502/contributor-guide>

-->
