### PR TITLE
`require` library `char-fold` when `char-fold-table` not bound.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,13 @@ The format is based on [Keep a Changelog].
 ### Bugs fixed
 * Toggling off filter methods no longer accidentally changes the
   global value of `prescient-filter-method`.  See [#123], [#124].
+* For character folding, if `char-fold-table` isn't bound, we
+  `require` the library `char-fold`. This variable apparently isn't
+  always loaded when we call `char-fold-to-regexp`. See [#126].
 
 [#123]: https://github.com/radian-software/prescient.el/issues/123
 [#124]: https://github.com/radian-software/prescient.el/pull/124
+[#126]: https://github.com/radian-software/prescient.el/pull/126
 
 ## 5.2.1 (released 2022-06-01)
 ### Bugs fixed

--- a/prescient.el
+++ b/prescient.el
@@ -346,6 +346,11 @@ This is the same as `char-fold-to-regexp' but it works around
 https://github.com/raxod502/prescient.el/issues/71. The issue
 should really be fixed upstream in Emacs, but it looks like that
 is not happening anytime soon."
+  ;; This variable apparently isn't always loaded when calling
+  ;; `char-fold-to-regexp'. If it isn't, then we get an error about
+  ;; trying to set the constant `nil'.
+  (unless (boundp 'char-fold-table)
+    (require 'char-fold))
   (let ((regexp (char-fold-to-regexp string)))
     (condition-case _
         (prog1 regexp


### PR DESCRIPTION
This came up while testing the completion style. `char-fold-to-regexp` will try to use `char-fold-table`, which won't be bound for some reason. Explicitly `require`-ing the library fixes this. 

This is on Emacs 28.1 with native-comp.