### PR TITLE
Fix literal filter methods when not using character folding.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,10 +10,14 @@ The format is based on [Keep a Changelog].
 * For character folding, if `char-fold-table` isn't bound, we
   `require` the library `char-fold`. This variable apparently isn't
   always loaded when we call `char-fold-to-regexp`. See [#126].
+* Fix the filter methods `literal` and `literal-prefix` not being
+  literal when `prescient-use-char-folding` was nil. This bug was
+  added with that user option. See [#127].
 
 [#123]: https://github.com/radian-software/prescient.el/issues/123
 [#124]: https://github.com/radian-software/prescient.el/pull/124
 [#126]: https://github.com/radian-software/prescient.el/pull/126
+[#127]: https://github.com/radian-software/prescient.el/pull/127
 
 ## 5.2.1 (released 2022-06-01)
 ### Bugs fixed

--- a/prescient.el
+++ b/prescient.el
@@ -46,6 +46,9 @@
 
 ;;;; Libraries
 
+;; Require `char-fold' so that `char-fold-table' gets defined.
+;; Otherwise `char-fold-to-regexp' can signal an error.
+(require 'char-fold)
 (require 'cl-lib)
 (require 'subr-x)
 
@@ -346,11 +349,6 @@ This is the same as `char-fold-to-regexp' but it works around
 https://github.com/raxod502/prescient.el/issues/71. The issue
 should really be fixed upstream in Emacs, but it looks like that
 is not happening anytime soon."
-  ;; This variable apparently isn't always loaded when calling
-  ;; `char-fold-to-regexp'. If it isn't, then we get an error about
-  ;; trying to set the constant `nil'.
-  (unless (boundp 'char-fold-table)
-    (require 'char-fold))
   (let ((regexp (char-fold-to-regexp string)))
     (condition-case _
         (prog1 regexp
@@ -421,7 +419,7 @@ See also the customizable variable `prescient-use-char-folding'."
   (prescient-with-group
    (if prescient-use-char-folding
        (prescient--char-fold-to-regexp query)
-     query)
+     (regexp-quote query))
    (eq with-group 'all)))
 
 (cl-defun prescient-literal-prefix-regexp
@@ -443,7 +441,7 @@ See also the customizable variable `prescient-use-char-folding'."
              "\\b")
            (if prescient-use-char-folding
                (prescient--char-fold-to-regexp query)
-             query))
+             (regexp-quote query)))
    (eq with-group 'all)))
 
 (cl-defun prescient-initials-regexp (query &key with-group


### PR DESCRIPTION
When `prescient-use-char-folding` was added, the `literal` and `literal-prefix` methods were mistakenly changed to only be literal when folding characters.
