### PR TITLE
Remove `prescient-completion-enable-sort` to avoid confusion.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,23 +24,13 @@ The format is based on [Keep a Changelog].
   works with UIs like Emacs's built-in minibuffer completion,
   Icomplete, and Vertico. See various discussions in [#125], [#120],
   [#112], [#89], [#58], and [#54].
-  * In Emacs 27+, this completion style can optionally modify
-    unsorted completion tables to use `prescient.el` sorting instead.
-    This behavior can be enabled by setting the new user option
-    `prescient-completion-enable-sort` to `t`. Note that this might
-    lead to sorting candidates twice, such as when
-    `company-prescient-mode` is enabled and a Company backend filters
-    using the `prescient` completion style.
-  * The modification sets the sorting function to the new function
-    `prescient-completion-sort`, which combines `prescient-sort` with
-    the new function `prescient-sort-full-matches-first`. This
-    function is meant to be used after filtering.
-
-    Some completion UIs allow explicitly setting the sorting function.
-    Setting such an option to `prescient-completion-sort` is
-    recommended to use prescient.el's sorting with other completion
-    styles and backends. Note that sorting fully matched candidates
-    before others only works for candidates filtered by `prescient`.
+* Add new function `prescient-completion-sort`, which combines
+  `prescient-sort` with the new function
+  `prescient-sort-full-matches-first`. See [#125]. This function is
+  meant to be used after filtering and as the sorting function of your
+  preferred completion UI. Note that sorting fully matched candidates
+  before partially matched candidates only works for candidates
+  filtered by the `prescient` completion style.
 * Added user option `prescient-completion-highlight-matches`, which
   determines whether the completion style highlights the matching
   parts of candidates with the above new faces ([#125]).

--- a/README.md
+++ b/README.md
@@ -66,11 +66,7 @@ prefer.
   2. Configure your completion UI to call `prescient-remember` on the
      chosen candidate so that candidates are sorted correctly.
   3. Configure your completion UI to sort filtered candidates via
-     `prescient-completion-sort` or a custom sorting function as
-     needed. Optionally, on Emacs 27+, you can instead set
-     `prescient-completion-enable-sort` (see below) to `t` to allow
-     the `prescient` completion style to set sorting directly. This
-     option is off by default to better work with various UIs.
+     `prescient-completion-sort`.
 
 Please note that **you must load Counsel before `ivy-prescient.el`**.
 This is because loading Counsel results in a number of changes being
@@ -152,27 +148,6 @@ completion style:
 
 * `prescient-completion-highlight-matches`: Whether the completion
   style should highlight matches in the filtered candidates.
-
-* `prescient-completion-enable-sort`: Whether, in Emacs 27+, the
-  completion style should automatically modify unsorted candidates to
-  instead use the function `prescient-completion-sort`. This is
-  disabled by default to be more generic and to avoid users
-  accidentally sorting candidates more than once, such as when
-  `company-prescient-mode` is enabled and the `prescient` completion
-  style is used to filter candidates in the Company backend.
-
-  This user option only controls sorting done by the `prescient`
-  completion style. It does not affect sorting for the other styles in
-  the `completion-style` user option.
-
-  Some completion UIs, such as [Vertico][vertico] and [Corfu][corfu],
-  allow you to explicitly set a default sorting function for unsorted
-  candidates. In that case, you could set such an option to
-  `prescient-completion-sort`, which wraps the functions
-  `prescient-sort` and `prescient-sort-full-matches-first`. This would
-  also allow you to use prescient.el's sorting (excluding
-  `prescient-sort-full-matches-first`) with other completion styles
-  and completion backends.
 
 ### For Company
 The following user options are specific to using `prescient.el`


### PR DESCRIPTION
It is better to make the various completion UIs use `prescient-completion-sort` directly, as this allows the sorting of candidates filtered by other completion styles and avoids Company Prescient re-sorting candidates from `company-capf`.

To keep things simple, the option of modifying completion-table metadata is removed.

See #129 and conversations in minad/vertico#237.