### PR TITLE
Create `vertico-prescient-mode` and `corfu-prescient-mode`.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,13 +3,27 @@
 All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog].
 
+## Unreleased
+### New features
+* Add package `vertico-prescient`, which integrates prescient.el with
+  Vertico ([#131]). New mode `vertico-prescient-mode` configures
+  sorting, candidate remembrance, filtering, and binds the toggling
+  commands in Vertico.
+
+* Add package `corfu-prescient`, which integrates prescient.el with
+  Corfu ([#131]). New mode `corfu-prescient-mode` configures
+  sorting, candidate remembrance, filtering, and binds the toggling
+  commands while the Corfu pop-up is active.
+
 ## 6.0 (released 2022-11-11)
 ### Bugs fixed
 * Toggling off filter methods no longer accidentally changes the
   global value of `prescient-filter-method`.  See [#123], [#124].
+
 * For character folding, if `char-fold-table` isn't bound, we
   `require` the library `char-fold`. This variable apparently isn't
   always loaded when we call `char-fold-to-regexp`. See [#126].
+
 * Fix the filter methods `literal` and `literal-prefix` not being
   literal when `prescient-use-char-folding` was nil. This bug was
   added with that user option. See [#127].
@@ -19,21 +33,25 @@ The format is based on [Keep a Changelog].
   implements the option. This feature already existed, but moving to a
   separate function makes it easier to support in more UIs. See
   [#125].
+
 * Add a completion style `prescient`. This completion style can be
   used in the variable `completion-styles`. This completion style
   works with UIs like Emacs's built-in minibuffer completion,
   Icomplete, and Vertico. See various discussions in [#125], [#120],
   [#112], [#89], [#58], and [#54].
+
 * Add new function `prescient-completion-sort`, which combines
   `prescient-sort` with the new function
-  `prescient-sort-full-matches-first`. See [#125]. This function is
+  `prescient-sort-full-matches-first` ([#125]). This function is
   meant to be used after filtering and as the sorting function of your
   preferred completion UI. Note that sorting fully matched candidates
   before partially matched candidates only works for candidates
   filtered by the `prescient` completion style.
+
 * Added user option `prescient-completion-highlight-matches`, which
   determines whether the completion style highlights the matching
   parts of candidates with the above new faces ([#125]).
+
 * Add faces `prescient-primary-highlight` and
   `prescient-secondary-highlight` ([#125]). These faces are used with
   the completion style and `selectrum-prescient.el`. The old faces
@@ -65,6 +83,7 @@ The format is based on [Keep a Changelog].
 [#125]: https://github.com/raxod502/prescient.el/pull/125
 [#126]: https://github.com/radian-software/prescient.el/pull/126
 [#127]: https://github.com/radian-software/prescient.el/pull/127
+[#131]: https://github.com/radian-software/prescient.el/pull/131
 
 ## 5.2.1 (released 2022-06-01)
 ### Bugs fixed

--- a/corfu-prescient.el
+++ b/corfu-prescient.el
@@ -1,0 +1,236 @@
+;;; corfu-prescient.el --- Corfu integration -*- lexical-binding: t -*-
+
+;; Copyright (C) 2022 Radian LLC and contributors
+
+;; Author: Radian LLC <contact+prescient@radian.codes>
+;; Homepage: https://github.com/radian-software/prescient.el
+;; Keywords: extensions
+;; Created: 23 Sep 2022
+;; Package-Requires: ((emacs "27.1") (prescient "5.2.1") (corfu "0.27"))
+;; SPDX-License-Identifier: MIT
+;; Version: 5.2.1
+
+;;; Commentary:
+
+;; corfu-prescient.el provides an interface for using prescient.el
+;; to sort and filter candidates in Corfu menus. To enable its
+;; functionality, turn on `corfu-prescient-mode' in your init-file
+;; or interactively.
+
+;; For more information, see https://github.com/radian-software/prescient.el.
+
+;;; Code:
+
+;;;; Libraries and Declarations
+
+(require 'cl-lib)
+(require 'corfu)
+(require 'prescient)
+(require 'subr-x)
+
+;;;; Customization
+
+(defgroup corfu-prescient nil
+  "Prescient adapter for Corfu."
+  :group 'convenience
+  :prefix "corfu-prescient"
+  :link '(url-link "https://github.com/radian-software/prescient.el"))
+
+(defcustom corfu-prescient-enable-filtering t
+  "Whether the `prescient' completion style is used in Corfu."
+  :type 'boolean
+  :group 'corfu-prescient)
+
+(defcustom corfu-prescient-enable-sorting t
+  "Whether prescient.el sorting is used in Corfu."
+  :type 'boolean
+  :group 'corfu-prescient)
+
+(defcustom corfu-prescient-override-sorting nil
+  "Whether to force sorting by `corfu-prescient'.
+
+If non-nil, then `corfu-prescient-mode' sets
+`corfu-sort-override-function' to the function
+`prescient-completion-sort'.
+
+Changing this variable will not take effect until
+`corfu-prescient-mode' has been reloaded."
+  :group 'corfu-prescient
+  :type 'boolean)
+
+(defcustom corfu-prescient-completion-styles
+  prescient--completion-recommended-styles
+  "The completion styles used by `corfu-prescient-mode'."
+  :group 'corfu-prescient
+  :type '(repeat symbol))
+
+(defcustom corfu-prescient-completion-category-overrides
+  prescient--completion-recommended-overrides
+  "The completion-category overrides used by `corfu-prescient-mode'."
+  :group 'corfu-prescient
+  :type '(repeat (cons symbol (repeat (cons symbol (repeat symbol))))))
+
+;;;; Toggling Commmands
+(defun corfu-prescient--toggle-refresh ()
+  "Refresh the Corfu UI.
+This function is added to `prescient--toggle-refresh-functions'
+by `corfu-prescient-mode'."
+  (when corfu--input
+    (setq corfu--input nil)
+    (corfu--update)))
+
+;;;; Minor mode
+(defvar corfu-prescient--old-sort-function nil
+  "Previous value of `corfu-sort-function'.")
+
+(defvar corfu-prescient--old-sort-override-function nil
+  "Previous value of `corfu-sort-override-function'.")
+
+(defvar corfu-prescient--old-toggle-binding nil
+  "Previous binding of `M-s' in `corfu-map'.")
+
+(defun corfu-prescient--remember (&rest _)
+  "Advice for remembering candidates in Corfu."
+  (when (>= corfu--index 0)
+    (prescient-remember
+     (substring-no-properties
+      (nth corfu--index corfu--candidates)))))
+
+(defvar-local corfu-prescient--local-settings nil
+  "Whether this buffer has local settings due to `corfu-prescient-mode'.")
+
+(defun corfu-prescient--apply-completion-settings ()
+  "Apply the local completion settings."
+  (prescient--completion-make-vars-local)
+  (prescient--completion-save-completion-settings)
+  (prescient--completion-apply-completion-settings
+   :styles corfu-prescient-completion-styles
+   :overrides corfu-prescient-completion-category-overrides)
+  (setq corfu-prescient--local-settings t))
+
+(defun corfu-prescient--undo-completion-settings ()
+  "Undo the local completion settings."
+  (prescient--completion-restore-completion-settings
+   :styles corfu-prescient-completion-styles
+   :overrides corfu-prescient-completion-category-overrides)
+  (prescient--completion-kill-local-vars)
+  (setq corfu-prescient--local-settings nil))
+
+(defun corfu-prescient--change-completion-settings (&rest _)
+  "Apply or undo the local completion settings in `corfu-mode-hook'."
+  (if corfu-mode
+      (unless corfu-prescient--local-settings
+        (corfu-prescient--apply-completion-settings))
+    ;; We need this here in case `corfu-mode' itself is disabled. We
+    ;; also need to undo things when `corfu-prescient-mode' is
+    ;; disabled, which happens in the mode's definition.
+    (when corfu-prescient--local-settings
+      (corfu-prescient--undo-completion-settings))))
+
+;;;###autoload
+(define-minor-mode corfu-prescient-mode
+  "Minor mode to use prescient.el in Corfu menus.
+
+This mode will:
+- if `corfu-prescient-override-sorting' is non-nil,
+  configure `corfu-sort-override-function' and set
+ `corfu-prescient-enable-filtering' to t
+
+- if `corfu-prescient-enable-filtering' is non-nil,
+  configure `corfu-sort-function'
+
+- if `corfu-prescient-enable-filtering' is non-nil:
+  - bind `prescient-toggle-map' to `M-s' in `corfu-map'
+  - change `completion-stlyes' to `corfu-prescient-completion-styles'
+  - apply `corfu-prescient-completion-category-overrides'
+    to `completion-category-overrides'
+  - set `completion-category-defaults' to nil
+
+- advise `corfu-insert' to remember candidates"
+  :global t
+  :group 'prescient
+  (if corfu-prescient-mode
+      ;; Turn on the mode.
+      (progn
+        ;; Prevent messing up variables if we explicitly enable the
+        ;; mode when it's already on.
+        (corfu-prescient-mode -1)
+        (setq corfu-prescient-mode t)
+
+        (when corfu-prescient-override-sorting
+          (setq corfu-prescient-enable-sorting t)
+          (cl-shiftf corfu-prescient--old-sort-override-function
+                     corfu-sort-override-function
+                     #'prescient-completion-sort))
+
+        (when corfu-prescient-enable-sorting
+          (cl-shiftf corfu-prescient--old-sort-function
+                     corfu-sort-function
+                     #'prescient-completion-sort))
+
+        (when corfu-prescient-enable-filtering
+          ;; Configure changing settings in the hook.
+          (add-hook 'corfu-mode-hook
+                    #'corfu-prescient--change-completion-settings)
+
+          ;; Immediately apply the settings in buffers where
+          ;; `corfu-mode' is already on.
+          (dolist (b (buffer-list))
+            (when (buffer-local-value corfu-mode b)
+              (with-current-buffer b
+                (corfu-prescient--apply-completion-settings))))
+
+          ;; Bind toggling commands.
+          (setq corfu-prescient--old-toggle-binding
+                (lookup-key corfu-map (kbd "M-s")))
+          (define-key corfu-map (kbd "M-s") prescient-toggle-map)
+
+          ;; Make sure Corfu refreshes immediately.
+          (add-hook 'prescient--toggle-refresh-functions
+                    #'corfu-prescient--toggle-refresh)
+
+          ;; Clean up the local versions of the toggling variables
+          ;; after the Corfu pop-up closes. For the toggling vars, it
+          ;; is the commands themselves that make the variables buffer
+          ;; local.
+          (cl-callf cl-union corfu--state-vars prescient--toggle-vars
+                    :test #'eq))
+
+        ;; While sorting might not be enabled in Corfu, it might
+        ;; still be enabled in another UI, such as Selectrum or Vertico.
+        ;; Therefore, we still want to remember candidates.
+        (advice-add 'corfu-insert :after #'corfu-prescient--remember))
+
+    ;; Turn off mode.
+
+    ;; Undo sorting settings.
+    (when (eq corfu-sort-function #'prescient-completion-sort)
+      (setq corfu-sort-function corfu-prescient--old-sort-function))
+    (when (eq corfu-sort-override-function #'prescient-completion-sort)
+      (setq corfu-sort-override-function
+            corfu-prescient--old-sort-override-function))
+
+    ;; Unbind toggling commands and unhook refresh function.
+    (when (equal (lookup-key corfu-map (kbd "M-s"))
+                 prescient-toggle-map)
+      (define-key corfu-map (kbd "M-s")
+        corfu-prescient--old-toggle-binding))
+    (remove-hook 'prescient--toggle-refresh-functions
+                 #'corfu-prescient--toggle-refresh)
+    (cl-callf cl-set-difference corfu--state-vars
+      prescient--toggle-vars
+      :test #'eq)
+
+    ;; Undo filtering settings.
+    (remove-hook 'corfu-mode-hook
+                 #'corfu-prescient--change-completion-settings)
+    (dolist (b (buffer-list))
+      (when (buffer-local-value 'corfu-prescient--local-settings b)
+        (with-current-buffer b
+          (corfu-prescient--undo-completion-settings))))
+
+    ;; Undo remembrance settings.
+    (advice-remove 'corfu-insert #'corfu-prescient--remember)))
+
+(provide 'corfu-prescient)
+;;; corfu-prescient.el ends here

--- a/selectrum-prescient.el
+++ b/selectrum-prescient.el
@@ -27,13 +27,6 @@
 (require 'selectrum)
 (require 'subr-x)
 
-(declare-function prescient--highlight-matches "prescient"
-                  (input candidates))
-(declare-function prescient-sort-full-matches-first "prescient"
-                  (candidates regexps ignore-case))
-(declare-function prescient-ignore-case-p "prescient"
-                  (input))
-
 ;;;; Customization
 
 (defgroup selectrum-prescient nil
@@ -61,6 +54,15 @@ this variable will not take effect until
 `selectrum-prescient-mode' has been reloaded."
   :group 'selectrum-prescient
   :type 'boolean)
+
+;;;; Toggling commands
+(defun selectrum-prescient--toggle-refresh ()
+  "Refresh the Selectrum UI.
+
+This function is added to `prescient--toggle-refresh-functions' by
+`selectrum-prescient-mode.'"
+  (when selectrum-is-active
+    (selectrum-exhibit)))
 
 ;;;; Minor mode
 
@@ -107,131 +109,6 @@ For use on `selectrum-candidate-selected-hook'."
 (defvar selectrum-prescient--old-highlight-function nil
   "Previous value of `selectrum-highlight-candidates-function'.")
 
-;;;;; Toggling Commands
-(defvar selectrum-prescient-toggle-map (make-sparse-keymap)
-  "A keymap of commands for toggling Prescient filters in Selectrum.
-Such commands are created and automatically bound in this map by
-`selectrum--prescient-create-and-bind-toggle-command'.")
-
-(defmacro selectrum-prescient-create-and-bind-toggle-command
-    (filter-type key-string)
-  "Create and bind a command to toggle the use of a filter method in Selectrum.
-
-The created command toggles the FILTER-TYPE algorithm on or off
-buffer-locally, and doesn't affect the default
-behavior (determined by `prescient-filter-method').
-
-FILTER-TYPE is an unquoted symbol that can be used in
-`prescient-filter-method'. KEY-STRING is a string that can be
-passed to `kbd', whose output will be bound in
-`selectrum-prescient-toggle-map' to the created command."
-  (let* ((filter-type-name (symbol-name filter-type)))
-
-    `(define-key selectrum-prescient-toggle-map
-       (kbd ,key-string)
-       (defun ,(intern (concat "selectrum-prescient-toggle-"
-                               filter-type-name))
-           (arg) ; Arg list
-         ,(format
-           "Toggle the \"%s\" filter on or off. With ARG, use only this filter.
-This toggling only affects filtering in the current Selectrum
-buffer. It does not affect the default behavior (determined by
-`prescient-filter-method')."  filter-type-name)
-         (interactive "P")
-
-         ;; Make `prescient-filter-method' buffer-local in the
-         ;; Selectrum buffer. We don't want to accidentally change the
-         ;; user's default behavior.
-         (make-local-variable 'prescient-filter-method)
-
-         (if arg
-             ;; If user provides a prefix argument, set filtering to
-             ;; be a list of only one filter type.
-             (setq prescient-filter-method '(,filter-type))
-
-           ;; Otherwise, if the current setting is a function,
-           ;; evaluate it to get the value.
-           (when (functionp prescient-filter-method)
-             (setq prescient-filter-method
-                   (funcall prescient-filter-method)))
-
-           ;; If we need to add or remove from the list, make sure
-           ;; it's actually a list and not just a symbol.
-           (when (symbolp prescient-filter-method)
-             (setq prescient-filter-method
-                   (list prescient-filter-method)))
-
-           (if (equal prescient-filter-method '(,filter-type))
-               ;; Make sure the user doesn't accidentally disable all
-               ;; filtering.
-               (user-error
-                "Prescient.el: Can't toggle off only active filter method: %s"
-                ,filter-type-name)
-
-             (setq prescient-filter-method
-                   (if (memq ',filter-type prescient-filter-method)
-                       ;; Even when running `make-local-variable',
-                       ;; it seems `delq' might still modify the
-                       ;; global value, so we use `remq' here.
-                       (remq ',filter-type prescient-filter-method)
-                     (cons ',filter-type prescient-filter-method)))))
-
-         ;; After changing `prescient-filter-method', tell the user
-         ;; the new value and update Selectrum's display.
-         (message "Prescient.el filter is now %s"
-                  prescient-filter-method)
-         (selectrum-exhibit)))))
-
-(selectrum-prescient-create-and-bind-toggle-command anchored "a")
-(selectrum-prescient-create-and-bind-toggle-command fuzzy "f")
-(selectrum-prescient-create-and-bind-toggle-command initialism "i")
-(selectrum-prescient-create-and-bind-toggle-command literal "l")
-(selectrum-prescient-create-and-bind-toggle-command literal-prefix "P")
-(selectrum-prescient-create-and-bind-toggle-command prefix "p")
-(selectrum-prescient-create-and-bind-toggle-command regexp "r")
-
-(defun selectrum-prescient-toggle-char-fold ()
-  "Toggle character folding in the current Selectrum buffer.
-
-See the customizable variable `prescient-use-char-folding'."
-  (interactive)
-  (setq-local prescient-use-char-folding
-              (not prescient-use-char-folding))
-  (message "Character folding toggled %s"
-           (if prescient-use-char-folding "on" "off"))
-  (selectrum-exhibit))
-
-;; This is the same binding used by `isearch-toggle-char-fold'.
-(define-key selectrum-prescient-toggle-map (kbd "'")
-  #'selectrum-prescient-toggle-char-fold)
-
-(defun selectrum-prescient-toggle-case-fold ()
-  "Toggle case folding in the current Selectrum buffer.
-
-If `prescient-use-case-folding' is set to `smart', then this
-toggles whether to use smart case folding or no case folding.
-Otherwise, this toggles between normal case folding and no case
-folding."
-  (interactive)
-  (setq-local prescient-use-case-folding
-              (cond
-               (prescient-use-case-folding
-                (message "Case folding toggled off")
-                nil)
-               ((eq (default-toplevel-value 'prescient-use-case-folding)
-                    'smart)
-                (message "Smart case folding toggled on")
-                'smart)
-               (t
-                (message "Case folding toggled on")
-                t)))
-
-  (selectrum-exhibit))
-
-;; This is the same binding used by `isearch-toggle-case-fold'.
-(define-key selectrum-prescient-toggle-map (kbd "c")
-  #'selectrum-prescient-toggle-case-fold)
-
 ;;;###autoload
 (define-minor-mode selectrum-prescient-mode
   "Minor mode to use prescient.el in Selectrum menus."
@@ -253,7 +130,9 @@ folding."
           (setq selectrum-highlight-candidates-function
                 #'prescient--highlight-matches)
           (define-key selectrum-minibuffer-map
-            (kbd "M-s") selectrum-prescient-toggle-map))
+            (kbd "M-s") prescient-toggle-map)
+          (add-hook 'prescient--toggle-refresh-functions
+                    #'selectrum-prescient--toggle-refresh))
         (when selectrum-prescient-enable-sorting
           (setq selectrum-prescient--old-preprocess-function
                 selectrum-preprocess-candidates-function)
@@ -272,8 +151,10 @@ folding."
       (setq selectrum-highlight-candidates-function
             selectrum-prescient--old-highlight-function))
     (when (equal (lookup-key selectrum-minibuffer-map (kbd "M-s"))
-                 selectrum-prescient-toggle-map)
+                 prescient-toggle-map)
       (define-key selectrum-minibuffer-map (kbd "M-s") nil))
+    (remove-hook 'prescient--toggle-refresh-functions
+                 #'selectrum-prescient--toggle-refresh)
     (remove-hook 'selectrum-candidate-selected-hook
                  #'selectrum-prescient--remember)
     (remove-hook 'selectrum-candidate-inserted-hook

--- a/stub/corfu.el
+++ b/stub/corfu.el
@@ -1,0 +1,15 @@
+;; This file contains stub definitions from corfu.el which allow
+;; corfu-prescient.el to be byte-compiled in the absence of
+;; corfu.el.
+
+(defvar corfu--candidates nil)
+(defvar corfu--index nil)
+(defvar corfu--input nil)
+(defvar corfu--state-vars nil)
+(defvar corfu-map nil)
+(defvar corfu-mode nil)
+(defvar corfu-sort-function nil)
+(defvar corfu-sort-override-function nil)
+(defun corfu--update (&optional interruptible))
+
+(provide 'corfu)

--- a/stub/selectrum.el
+++ b/stub/selectrum.el
@@ -7,6 +7,7 @@
 (defvar selectrum-highlight-candidates-function nil)
 (defvar selectrum-minibuffer-map nil)
 (defvar selectrum-should-sort nil)
+(defvar selectrum-is-active nil)
 
 (defun selectrum-exhibit ())
 

--- a/stub/vertico.el
+++ b/stub/vertico.el
@@ -1,0 +1,15 @@
+;; This file contains stub definitions from vertico.el which allow
+;; vertico-prescient.el to be byte-compiled in the absence of
+;; vertico.el.
+
+(defvar vertico--candidates nil)
+(defvar vertico--history-hash nil)
+(defvar vertico--index nil)
+(defvar vertico--input nil)
+(defvar vertico--lock-candidate nil)
+(defvar vertico-map nil)
+(defvar vertico-sort-function nil)
+(defvar vertico-sort-override-function nil)
+(defun vertico--exhibit ())
+
+(provide 'vertico)

--- a/vertico-prescient.el
+++ b/vertico-prescient.el
@@ -1,0 +1,214 @@
+;;; vertico-prescient.el --- Vertico integration -*- lexical-binding: t -*-
+
+;; Copyright (C) 2022 Radian LLC and contributors
+
+;; Author: Radian LLC <contact+prescient@radian.codes>
+;; Homepage: https://github.com/radian-software/prescient.el
+;; Keywords: extensions
+;; Created: 23 Sep 2022
+;; Package-Requires: ((emacs "27.1") (prescient "5.2.1") (vertico "0.27"))
+;; SPDX-License-Identifier: MIT
+;; Version: 5.2.1
+
+;;; Commentary:
+
+;; vertico-prescient.el provides an interface for using prescient.el
+;; to sort and filter candidates in Vertico menus. To enable its
+;; functionality, turn on `vertico-prescient-mode' in your init-file
+;; or interactively.
+
+;; For more information, see https://github.com/radian-software/prescient.el.
+
+;;; Code:
+
+;;;; Libraries and Declarations
+
+(eval-when-compile (require 'cl-lib))
+(require 'prescient)
+(require 'subr-x)
+(require 'vertico)
+
+;;;; Customization
+
+(defgroup vertico-prescient nil
+  "Prescient adapter for Vertico."
+  :group 'convenience
+  :prefix "vertico-prescient"
+  :link '(url-link "https://github.com/radian-software/prescient.el"))
+
+(defcustom vertico-prescient-enable-filtering t
+  "Whether the `prescient' completion style is used in Vertico."
+  :type 'boolean
+  :group 'vertico-prescient)
+
+(defcustom vertico-prescient-enable-sorting t
+  "Whether the `prescient' completion style is used in Vertico."
+  :type 'boolean
+  :group 'vertico-prescient)
+
+(defcustom vertico-prescient-override-sorting nil
+  "Whether to force sorting by `vertico-prescient'.
+
+If non-nil, then `vertico-prescient-mode' sets
+`vertico-sort-override-function' to the function
+`prescient-completion-sort'.
+
+Changing this variable will not take effect until
+`vertico-prescient-mode' has been reloaded."
+  :group 'vertico-prescient
+  :type 'boolean)
+
+(defcustom vertico-prescient-completion-styles
+  prescient--completion-recommended-styles
+  "The completion styles used by `vertico-prescient-mode'."
+  :group 'vertico-prescient
+  :type '(repeat symbol))
+
+(defcustom vertico-prescient-completion-category-overrides
+  prescient--completion-recommended-overrides
+  "The completion-category overrides used by `vertico-prescient-mode'."
+  :group 'vertico-prescient
+  :type '(repeat (cons symbol (repeat (cons symbol (repeat symbol))))))
+
+;;;; Toggling commands
+(defun vertico-prescient--toggle-refresh ()
+  "Refresh to Vertico UI.
+This function is added to `prescient--toggle-refresh-functions'
+by `vertico-prescient-mode'."
+  (when vertico--input
+    (setq vertico--input t
+          vertico--history-hash nil
+          vertico--lock-candidate nil)
+    (vertico--exhibit)))
+
+;;;; Minor mode
+
+(defvar vertico-prescient--old-sort-function nil
+  "Previous value of `vertico-sort-function'.")
+
+(defvar vertico-prescient--old-sort-override-function nil
+  "Previous value of `vertico-sort-override-function'.")
+
+(defvar vertico-prescient--old-toggle-binding nil
+  "Previous binding of `M-s' in `vertico-map'.")
+
+(defun vertico-prescient--remember ()
+  "Advice for remembering candidates in Vertico."
+  (when (>= vertico--index 0)
+    (prescient-remember
+     (substring-no-properties
+      (nth vertico--index vertico--candidates)))))
+
+(defvar-local vertico-prescient--local-settings nil
+  "Whether this buffer has local settings due to `vertico-prescient-mode'.")
+
+(defun vertico-prescient--apply-completion-settings ()
+  "Apply the local completion settings after `vertico--setup'."
+  (unless vertico-prescient--local-settings
+    (prescient--completion-make-vars-local)
+    (prescient--completion-save-completion-settings)
+    (prescient--completion-apply-completion-settings
+     :styles vertico-prescient-completion-styles
+     :overrides vertico-prescient-completion-category-overrides)
+    (setq vertico-prescient--local-settings t)))
+
+(defun vertico-prescient--undo-completion-settings ()
+  "Undo the local completion settings."
+  (prescient--completion-restore-completion-settings
+   :styles vertico-prescient-completion-styles
+   :overrides vertico-prescient-completion-category-overrides)
+  (prescient--completion-kill-local-vars)
+  (setq vertico-prescient--local-settings nil))
+
+;;;###autoload
+(define-minor-mode vertico-prescient-mode
+  "Minor mode to use prescient.el in Vertico menus.
+
+This mode will:
+- if `vertico-prescient-override-sorting' is non-nil,
+  configure `vertico-sort-override-function' and set
+ `vertico-prescient-enable-filtering' to t
+
+- if `vertico-prescient-enable-filtering' is non-nil,
+  configure `vertico-sort-function'
+
+- if `vertico-prescient-enable-filtering' is non-nil:
+  - bind `prescient-toggle-map' to `M-s' in `vertico-map'
+  - change `completion-stlyes' to `vertico-prescient-completion-styles'
+  - apply `vertico-prescient-completion-category-overrides'
+    to `completion-category-overrides'
+  - set `completion-category-defaults' to nil
+
+- advise `vertico-insert' to remember candidates"
+  :global t
+  :group 'prescient
+  (if vertico-prescient-mode
+      ;; Turn on the mode.
+      (progn
+        ;; Prevent messing up variables if we explicitly enable the
+        ;; mode when it's already on.
+        (vertico-prescient-mode -1)
+        (setq vertico-prescient-mode t)
+
+        (when vertico-prescient-override-sorting
+          (setq vertico-prescient-enable-sorting t)
+          (cl-shiftf vertico-prescient--old-sort-override-function
+                     vertico-sort-override-function
+                     #'prescient-completion-sort))
+
+        (when vertico-prescient-enable-sorting
+          (cl-shiftf vertico-prescient--old-sort-function
+                     vertico-sort-function
+                     #'prescient-completion-sort))
+
+        (when vertico-prescient-enable-filtering
+          ;; Configure completion settings.
+          (advice-add 'vertico--setup
+                      :after #'vertico-prescient--apply-completion-settings)
+
+          ;; Bind toggling commands.
+          (setq vertico-prescient--old-toggle-binding
+                (lookup-key vertico-map (kbd "M-s")))
+          (define-key vertico-map (kbd "M-s") prescient-toggle-map)
+
+          ;; Make sure Vertico refreshes immediately.
+          (add-hook 'prescient--toggle-refresh-functions
+                    #'vertico-prescient--toggle-refresh))
+
+        ;; While sorting might not be enabled in Vertico, it might
+        ;; still be enabled in another UI, such as Company or Corfu.
+        ;; Therefore, we still want to remember candidates.
+        (advice-add 'vertico-insert :after #'vertico-prescient--remember))
+
+    ;; Turn off mode.
+
+    ;; Undo sorting settings.
+    (when (eq vertico-sort-function #'prescient-completion-sort)
+      (setq vertico-sort-function vertico-prescient--old-sort-function))
+    (when (eq vertico-sort-override-function #'prescient-completion-sort)
+      (setq vertico-sort-override-function
+            vertico-prescient--old-sort-override-function))
+
+    ;; Unbind toggling commands and unhook refresh function.
+    (when (equal (lookup-key vertico-map (kbd "M-s"))
+                 prescient-toggle-map)
+      (define-key vertico-map (kbd "M-s")
+        vertico-prescient--old-toggle-binding))
+    (remove-hook 'prescient--toggle-refresh-functions
+                 #'vertico-prescient--toggle-refresh)
+
+    ;; Undo filtering settings.
+    (advice-remove 'vertico--setup
+                   #'vertico-prescient--apply-completion-settings)
+    (dolist (b (buffer-list))
+      (when (buffer-local-value 'vertico-prescient--local-settings b)
+        (with-current-buffer b
+          (vertico-prescient--undo-completion-settings))))
+
+    ;; Undo remembrance settings.
+    (advice-remove 'vertico-insert #'vertico-prescient--remember)))
+
+(provide 'vertico-prescient)
+;;; vertico-prescient.el ends here
+
+;; LocalWords:  Vertico's


### PR DESCRIPTION
- Create files `vertico-prescient.el` and `corfu-prescient.el`.
- Add stub definitions for Vertico and Corfu.
- Make the `selectrum-prescient-toggle-*` commands more generic and move them to `prescient.el`.
  - Add variable `prescient--toggle-refresh-functions` and function `prescient--toggle-refresh`. The toggle commands run this hook to refresh the UI. Integration packages add functions to this hook.
  - Extract out new macro `prescient-create-toggling-command` from the existing `prescient-create-and-bind-toggling-command`.
- Create a `prescient-completion-mode`. This minor mode will handle the completion settings shared by `vertico-prescient-mode` and `corfu-prescient-mode`.

# TODO

- [x] Should the toggling command be bound in the Corfu map? Do they make sense there?
  - Thinking no. They would need to work differently for Corfu, and adjusting the filtering on the fly suggests a more involved (for lack of a better term) completion session than how Corfu is probably used. To switch to the minibuffer, there is already a command  given on the Corfu GitHub page.