### PR TITLE
Update package version and requirements to correct versions.

### DIFF
--- a/corfu-prescient.el
+++ b/corfu-prescient.el
@@ -6,9 +6,9 @@
 ;; Homepage: https://github.com/radian-software/prescient.el
 ;; Keywords: extensions
 ;; Created: 23 Sep 2022
-;; Package-Requires: ((emacs "27.1") (prescient "5.2.1") (corfu "0.27"))
+;; Package-Requires: ((emacs "27.1") (prescient "6.0.0") (corfu "0.28"))
 ;; SPDX-License-Identifier: MIT
-;; Version: 5.2.1
+;; Version: 6.0.0
 
 ;;; Commentary:
 

--- a/vertico-prescient.el
+++ b/vertico-prescient.el
@@ -6,9 +6,9 @@
 ;; Homepage: https://github.com/radian-software/prescient.el
 ;; Keywords: extensions
 ;; Created: 23 Sep 2022
-;; Package-Requires: ((emacs "27.1") (prescient "5.2.1") (vertico "0.27"))
+;; Package-Requires: ((emacs "27.1") (prescient "6.0.0") (vertico "0.28"))
 ;; SPDX-License-Identifier: MIT
-;; Version: 5.2.1
+;; Version: 6.0.0
 
 ;;; Commentary:
 


### PR DESCRIPTION
- Corfu and Vertico to version 0.28 in package requirements
- `prescient.el`, `corfu-prescient.el`, and `vertico-prescient.el` to version 6.0.0
   in package requirements and description