### PR TITLE
Bump version number to 6.1.0 to make NonGNU ELPA install correct version.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog].
 
-## Unreleased
+## 6.1 (released 2022-12-16)
 ### New features
 * Add package `vertico-prescient`, which integrates prescient.el with
   Vertico ([#131]). New mode `vertico-prescient-mode` configures
@@ -14,6 +14,8 @@ The format is based on [Keep a Changelog].
   Corfu ([#131]). New mode `corfu-prescient-mode` configures
   sorting, candidate remembrance, filtering, and binds the toggling
   commands while the Corfu pop-up is active.
+
+[#131]: https://github.com/radian-software/prescient.el/pull/131
 
 ## 6.0 (released 2022-11-11)
 ### Bugs fixed
@@ -83,7 +85,6 @@ The format is based on [Keep a Changelog].
 [#125]: https://github.com/raxod502/prescient.el/pull/125
 [#126]: https://github.com/radian-software/prescient.el/pull/126
 [#127]: https://github.com/radian-software/prescient.el/pull/127
-[#131]: https://github.com/radian-software/prescient.el/pull/131
 
 ## 5.2.1 (released 2022-06-01)
 ### Bugs fixed

--- a/company-prescient.el
+++ b/company-prescient.el
@@ -6,9 +6,9 @@
 ;; Homepage: https://github.com/raxod502/prescient.el
 ;; Keywords: extensions
 ;; Created: 7 May 2018
-;; Package-Requires: ((emacs "25.1") (prescient "6.0.0") (company "0.9.6"))
+;; Package-Requires: ((emacs "25.1") (prescient "6.1.0") (company "0.9.6"))
 ;; SPDX-License-Identifier: MIT
-;; Version: 6.0.0
+;; Version: 6.1.0
 
 ;;; Commentary:
 

--- a/corfu-prescient.el
+++ b/corfu-prescient.el
@@ -6,9 +6,9 @@
 ;; Homepage: https://github.com/radian-software/prescient.el
 ;; Keywords: extensions
 ;; Created: 23 Sep 2022
-;; Package-Requires: ((emacs "27.1") (prescient "6.0.0") (corfu "0.28"))
+;; Package-Requires: ((emacs "27.1") (prescient "6.1.0") (corfu "0.28"))
 ;; SPDX-License-Identifier: MIT
-;; Version: 6.0.0
+;; Version: 6.1.0
 
 ;;; Commentary:
 

--- a/ivy-prescient.el
+++ b/ivy-prescient.el
@@ -6,9 +6,9 @@
 ;; Homepage: https://github.com/raxod502/prescient.el
 ;; Keywords: extensions
 ;; Created: 1 May 2018
-;; Package-Requires: ((emacs "25.1") (prescient "6.0.0") (ivy "0.11.0"))
+;; Package-Requires: ((emacs "25.1") (prescient "6.1.0") (ivy "0.11.0"))
 ;; SPDX-License-Identifier: MIT
-;; Version: 6.0.0
+;; Version: 6.1.0
 
 ;;; Commentary:
 

--- a/prescient.el
+++ b/prescient.el
@@ -8,7 +8,7 @@
 ;; Created: 7 Aug 2017
 ;; Package-Requires: ((emacs "25.1"))
 ;; SPDX-License-Identifier: MIT
-;; Version: 6.0.0
+;; Version: 6.1.0
 
 ;;; Commentary:
 

--- a/selectrum-prescient.el
+++ b/selectrum-prescient.el
@@ -6,9 +6,9 @@
 ;; Homepage: https://github.com/raxod502/prescient.el
 ;; Keywords: extensions
 ;; Created: 8 Dec 2019
-;; Package-Requires: ((emacs "25.1") (prescient "6.0.0") (selectrum "3.1"))
+;; Package-Requires: ((emacs "25.1") (prescient "6.1.0") (selectrum "3.1"))
 ;; SPDX-License-Identifier: MIT
-;; Version: 6.0.0
+;; Version: 6.1.0
 
 ;;; Commentary:
 

--- a/vertico-prescient.el
+++ b/vertico-prescient.el
@@ -6,9 +6,9 @@
 ;; Homepage: https://github.com/radian-software/prescient.el
 ;; Keywords: extensions
 ;; Created: 23 Sep 2022
-;; Package-Requires: ((emacs "27.1") (prescient "6.0.0") (vertico "0.28"))
+;; Package-Requires: ((emacs "27.1") (prescient "6.1.0") (vertico "0.28"))
 ;; SPDX-License-Identifier: MIT
-;; Version: 6.0.0
+;; Version: 6.1.0
 
 ;;; Commentary:
 


### PR DESCRIPTION
NonGNU ELPA uses the commit that changed the version number as the stable version of the files. Therefore, without the bump, it would install an older version of the file `prescient.el`, which won't work with the Vertico and Corfu integration packages.
