### PR TITLE
Add an `.elpaignore` file.

### DIFF
--- a/.elpaignore
+++ b/.elpaignore
@@ -1,0 +1,5 @@
+Dockerfile
+.github
+Makefile
+scripts
+stub


### PR DESCRIPTION
This file is describe in GNU ELPA's README
(https://git.savannah.gnu.org/cgit/emacs/elpa.git/tree/README) under the heading "Format".  There, it is stated that the patterns of files are passed to `tar`'s `-X` (`--exclude-from=`) switch.

This simplifies the `:ignored-files` part of the ELPA package specification.

The recommendation for adding the file was made on the Emacs Devel mailing list (https://lists.gnu.org/archive/html/emacs-devel/2022-12/msg00775.html).