### PR TITLE
Only add properties for `prescient-sort-full-matches-first` to the first candidate.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog].
 
+## Unreleased
+
+### Internal Changes
+
+* `prescient-filter` now only propertizes the first returned candidate
+  for use with `prescient-sort-full-matches-first` ([#148]). Custom
+  sorting functions using this data should be changed to search the
+  candidates for the properties, as in `prescient--get-sort-info`.
+
+[#148]: https://github.com/radian-software/prescient.el/pull/148
+
 ## 6.1 (released 2022-12-16)
 ### New features
 * Add package `vertico-prescient`, which integrates prescient.el with


### PR DESCRIPTION
Only add properties to the first candidate, and search for the properties in the candidates list. This should be better than what we do now, which is to propertize every candidate and later get the properties from the first candidate in the list.

For N candidates, the old way is always

    (propertize N) + (search 1) + (sort N)

and the new way is

    (propertize 1) + (search (N - x)) + (sort N)

where x is greater than or equal to 0. Assuming that `get-text-property` is no worse than `propertize` (which seems true in testing), the new way is never worse than the old way, and should usually be better.

<!--

To expedite the pull request process, please see the contributor guide
for my projects:

  <https://github.com/raxod502/contributor-guide>

-->
