### PR TITLE
Support `completion-lazy-hilit` and `completion-lazy-hilit-fn` for Emacs 30.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,15 @@
 All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog].
 
+## Unreleased
+### Enhancements
+* The completion style now supports lazy highlighting via
+  `completion-lazy-hilit` and `completion-lazy-hilit-fn`, new in Emacs
+  30 and already supported by some completion UIs ([#152], [#153]).
+
+[#152]: https://github.com/radian-software/prescient.el/issues/152
+[#153]: https://github.com/radian-software/prescient.el/pull/153
+
 ## 6.2 (released 2023-11-23)
 ### Features
 * New user option `prescient-tiebreaker` which can be used to change

--- a/selectrum-prescient.el
+++ b/selectrum-prescient.el
@@ -128,7 +128,7 @@ For use on `selectrum-candidate-selected-hook'."
           (setq selectrum-refine-candidates-function
                 #'selectrum-prescient--refine)
           (setq selectrum-highlight-candidates-function
-                #'prescient--highlight-matches)
+                #'prescient--highlight-candidates)
           (define-key selectrum-minibuffer-map
             (kbd "M-s") prescient-toggle-map)
           (add-hook 'prescient--toggle-refresh-functions
@@ -147,7 +147,7 @@ For use on `selectrum-candidate-selected-hook'."
       (setq selectrum-refine-candidates-function
             selectrum-prescient--old-refine-function))
     (when (eq selectrum-highlight-candidates-function
-              #'prescient--highlight-matches)
+              #'prescient--highlight-candidates)
       (setq selectrum-highlight-candidates-function
             selectrum-prescient--old-highlight-function))
     (when (equal (lookup-key selectrum-minibuffer-map (kbd "M-s"))


### PR DESCRIPTION
This feature allows highlighting to occur later instead of being
performed by the completion style immediately.

- Move logic for highlighting a single candidate from
  `prescient--highlight-matches` to `prescient--highlight-candidate`.

- Rename `prescient--highlight-matches` to
  `prescient--highlight-candidates`, which now applies the new
  function to a list of candidates.
  - Keep this function to support
    `prescient-completion-highlight-matches`, which is now obsolete.

See:
- Prescient issue #152
  (#152)

- Emacs bug #47711
  (https://debbugs.gnu.org/cgi/bugreport.cgi?bug=47711)

- Emacs commit dfffb91a70532ac0021648ba692336331cbe0499
  (https://git.savannah.gnu.org/cgit/emacs.git/commit/?id=dfffb91a70532ac0021648ba692336331cbe0499),

- Vertico commit b11040e1e9c1a4e5178800a0d0925aeeb72dd027
  (minad/vertico@b11040e)

- This Prescient PR #153.

<!--

To expedite the pull request process, please see the contributor guide
for my projects:

  <https://github.com/raxod502/contributor-guide>

-->
