### PR TITLE
Vertico Prescient: Change how candidates are remembered.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,8 +9,14 @@ The format is based on [Keep a Changelog].
   `completion-lazy-hilit` and `completion-lazy-hilit-fn`, new in Emacs
   30 and already supported by some completion UIs ([#152], [#153]).
 
+### Bugs fixed
+* Change how candidates are remembered for Vertico to work with
+  `vertico-directory-enter` and to remember the minibuffer contents
+  when exiting the minibuffer.
+
 [#152]: https://github.com/radian-software/prescient.el/issues/152
 [#153]: https://github.com/radian-software/prescient.el/pull/153
+[#156]: https://github.com/radian-software/prescient.el/pull/156
 
 ## 6.2 (released 2023-11-23)
 ### Features

--- a/stub/compat.el
+++ b/stub/compat.el
@@ -1,0 +1,7 @@
+;; This file contains stub definitions from compat.el which allows
+;; files to be byte-compiled in the absence of compat.el.
+
+(unless (fboundp 'file-name-split)
+  (defun file-name-split (_FILENAME)))
+
+(provide 'compat)


### PR DESCRIPTION

- Fix #155, remembering candidates when entering a new directory
  with `vertico-directory-enter`.
- Remember candidates on minibuffer exit as well as candidate
  insertion.

- Remove `vertico-prescient--remember`.
- Add `vertico-prescient--remember-minibuffer-contents`.  If
  completing a file name, only remember the last component of
  the file path, since that is the actual candidate.  If the candidate
  is a directory, include the trailing directory separator.
- Add `vertico-prescient--insertion-commands` and
  `vertico-prescient--remember-inserted-candidate` for remembering
  in `post-command-hook`.
- Add `vertico-prescient--remember-exited-candidate` and
  `vertico-prescient--exit-commands` for remembering in
  `minibuffer-exit-hook`.
- Hook `vertico-prescient--setup-remembrance` into
  `minibuffer-setup-hook`.
