### PR TITLE
Improve testing setup.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,11 +10,13 @@ jobs:
     strategy:
       matrix:
         emacs_version: [25, 26, 27, 28]
+        make_target: ['checkdoc', 'longlines', 'test', 'compile']
     steps:
       - name: Checkout
         uses: actions/checkout@v2
       - name: CI
         env:
           VERSION: ${{ matrix.emacs_version }}
+          TARGET: ${{ matrix.make_target }}
         run: >-
-          make docker CMD="make -k compile checkdoc longlines test"
+          make docker CMD="make -k $TARGET VERSION=$VERSION"

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,19 @@ CMD ?=
 EMACS ?= emacs
 
 # The order is important for compilation.
+#
+# Get all files for which we might wish to test compilation, then
+# remove files that we shouldn't test based on the Emacs version.
 for_compile := prescient.el $(wildcard *-prescient.el)
+ifneq ($(strip $(VERSION)),)
+  ifeq (1, $(strip $(shell expr $(VERSION) \< 26)))
+    for_compile := $(filter-out selectrum-prescient.el,$(for_compile))
+  endif
+  ifeq (1, $(strip $(shell expr $(VERSION) \< 27)))
+    for_compile := $(filter-out vertico-prescient.el corfu-prescient.el,\
+                                $(for_compile))
+  endif
+endif
 for_checkdoc := prescient.el $(wildcard *-prescient.el)
 for_longlines := $(wildcard *.el *.md *.yml) Makefile
 

--- a/scripts/check-line-length.bash
+++ b/scripts/check-line-length.bash
@@ -14,9 +14,16 @@ find=(
 
 readarray -t files < <("${find[@]}" | sed 's#./##' | sort)
 
+# Don't print the line length if:
+# - If it is the first line
+# - It is the Requirements line
+# - The line contains a URL
 code="$(cat <<"EOF"
 
-(NR > 1 && length($0) >= 80 && $0 !~ /https?:\/\//) \
+((NR > 1) \
+ && ($0 !~ /^;; Package-Requires:/) \
+ && (length($0) >= 80) \
+ && ($0 !~ /https?:\/\//)) \
 { printf "%s:%d: %s\n", FILENAME, NR, $0 }
 
 EOF


### PR DESCRIPTION
- Don't test the compilation of files for which the Emacs version is
  too low for the UI. For example, Vertico requires Emacs 27.1, so we
  shouldn't bother testing `vertico-prescient.el` with Emacs versions
  less than that. This makes implementations a bit simpler.
- To do that, explicitly pass the version argument
  for the `docker` `make` target.
- Don't raise an error for long line of package requirements.
